### PR TITLE
Support new x-pack API URLs in ES 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ POST to Elasticsearch. To do this, we used the `elastic` superuser whose passwor
 $ curl \
     -X POST \
     -H "Content-Type: application/json" \
-    -d '{"cluster": ["manage_security"]}' \
+    -d '{"cluster": ["manage_security", "monitor"]}' \
     http://elastic:$PASSWORD@localhost:9200/_xpack/security/role/vault
 ```
 

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -57,7 +57,7 @@ Also create a 'vault' role for Test_ExternallyDefinedRole, ex:
 $ curl \
     -k -X POST \
     -H "Content-Type: application/json" \
-    -d '{"cluster": ["manage_security"]}' \
+    -d '{"cluster": ["manage_security", "monitor"]}' \
     https://elastic:$ES_PASSWORD@localhost:9200/_xpack/security/role/vault
 
 */
@@ -178,7 +178,7 @@ func (e *Environment) Test_InternallyDefinedRole(t *testing.T) {
 	// Write the role.
 	writeResp, err := e.doVaultReq(http.MethodPost, "/v1/database/roles/internally-defined-role", map[string]interface{}{
 		"db_name":             "my-elasticsearch-database",
-		"creation_statements": `{"elasticsearch_role_definition": {"cluster": ["manage_security"]}}`,
+		"creation_statements": `{"elasticsearch_role_definition": {"cluster": ["manage_security", "monitor"]}}`,
 		"default_ttl":         "1h",
 		"max_ttl":             "24h",
 	})
@@ -208,7 +208,7 @@ func (e *Environment) Test_InternallyDefinedRole(t *testing.T) {
 		t.Fatal("expected creation_statements but they weren't returned")
 	} else if len(stmts.([]interface{})) != 1 {
 		t.Fatalf("expected 1 creation_statements but received %s", stmts)
-	} else if fmt.Sprintf("%s", stmts.([]interface{})[0]) != `{"elasticsearch_role_definition": {"cluster": ["manage_security"]}}` {
+	} else if fmt.Sprintf("%s", stmts.([]interface{})[0]) != `{"elasticsearch_role_definition": {"cluster": ["manage_security", "monitor"]}}` {
 		t.Fatalf("received unexpected statement: %s", stmts.([]interface{})[0])
 	}
 	if respData["default_ttl"].(float64) != 3600 {

--- a/integration_test.go
+++ b/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -32,27 +33,32 @@ const (
 )
 
 func TestIntegration_Container(t *testing.T) {
-	cleanup, client, retAddress := prepareTestContainer(t)
-	defer cleanup()
-	verifyTestContainer(t, retAddress)
-	tc := NewElasticSearchEnv(t, client, retAddress)
+	versions := []string{"6.8.13", "7.9.1"}
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			cleanup, client, retAddress := prepareTestContainer(t, version)
+			defer cleanup()
+			verifyTestContainer(t, retAddress)
+			tc := NewElasticSearchEnv(t, client, retAddress, version)
 
-	env := &IntegrationTestEnv{
-		Username:      esVaultUser,
-		Password:      esVaultPassword,
-		URL:           tc.BaseURL,
-		CaCert:        filepath.Join("testdata", "certs", "rootCA.pem"),
-		ClientCert:    filepath.Join("testdata", "certs", "client.pem"),
-		ClientKey:     filepath.Join("testdata", "certs", "client-key.pem"),
-		Elasticsearch: &Elasticsearch{},
-		TestUsers:     make(map[string]dbplugin.Statements),
-		TestCreds:     make(map[string]string),
-		tc:            tc,
+			env := &IntegrationTestEnv{
+				Username:      esVaultUser,
+				Password:      esVaultPassword,
+				URL:           tc.BaseURL,
+				CaCert:        filepath.Join("testdata", "certs", "rootCA.pem"),
+				ClientCert:    filepath.Join("testdata", "certs", "client.pem"),
+				ClientKey:     filepath.Join("testdata", "certs", "client-key.pem"),
+				Elasticsearch: &Elasticsearch{},
+				TestUsers:     make(map[string]dbplugin.Statements),
+				TestCreds:     make(map[string]string),
+				tc:            tc,
+			}
+			t.Run("test init", env.TestElasticsearch_Initialize)
+			t.Run("test create user", env.TestElasticsearch_NewUser)
+			t.Run("test delete user", env.TestElasticsearch_DeleteUser)
+			t.Run("test update user", env.TestElasticsearch_UpdateUser)
+		})
 	}
-	t.Run("test init", env.TestElasticsearch_Initialize)
-	t.Run("test create user", env.TestElasticsearch_NewUser)
-	t.Run("test delete user", env.TestElasticsearch_DeleteUser)
-	t.Run("test update user", env.TestElasticsearch_UpdateUser)
 }
 
 type IntegrationTestEnv struct {
@@ -62,7 +68,20 @@ type IntegrationTestEnv struct {
 	TestUsers                     map[string]dbplugin.Statements
 	TestCreds                     map[string]string
 
+	// Control whether using /_xpack/security or /_security
+	XPackStr string
+
 	tc *ElasticSearchEnv
+}
+
+func tgetXPackStr(t *testing.T, version string) string {
+	t.Helper()
+
+	split := strings.Split(version, ".")
+	if split[0] < "7" {
+		return "/_xpack/security"
+	}
+	return "/_security"
 }
 
 func (e *IntegrationTestEnv) TestElasticsearch_Initialize(t *testing.T) {
@@ -176,7 +195,7 @@ func readCertFile(t *testing.T, filename string) []byte {
 	return b
 }
 
-func prepareTestContainer(t *testing.T) (cleanup func(), client *http.Client, retAddress string) {
+func prepareTestContainer(t *testing.T, version string) (cleanup func(), client *http.Client, retAddress string) {
 	t.Helper()
 
 	certsdir, err := filepath.Abs(filepath.Join("testdata", "certs"))
@@ -203,7 +222,7 @@ func prepareTestContainer(t *testing.T) (cleanup func(), client *http.Client, re
 
 	dockerOptions := &dockertest.RunOptions{
 		Repository: "docker.elastic.co/elasticsearch/elasticsearch",
-		Tag:        "7.3.0",
+		Tag:        version,
 		WorkingDir: "/usr/share/elasticsearch/",
 		Mounts:     []string{certsdir + ":/usr/share/elasticsearch/config/certificates"},
 		Env:        env,
@@ -342,9 +361,10 @@ type ElasticSearchEnv struct {
 	Username, Password string
 	BaseURL            string
 	Client             *http.Client
+	XPackStr           string
 }
 
-func NewElasticSearchEnv(t *testing.T, client *http.Client, retAddress string) *ElasticSearchEnv {
+func NewElasticSearchEnv(t *testing.T, client *http.Client, retAddress string, version string) *ElasticSearchEnv {
 	t.Helper()
 
 	tc := &ElasticSearchEnv{
@@ -353,6 +373,11 @@ func NewElasticSearchEnv(t *testing.T, client *http.Client, retAddress string) *
 		Client:   client,
 		BaseURL:  retAddress,
 	}
+	xpackStr, err := getXPackStr(version)
+	if err != nil {
+		t.Fatalf("failed to determine Xpack api path: %s", err)
+	}
+	tc.XPackStr = xpackStr
 	// Set the elastic user's password
 	tc.SetPassword(t, "elastic", esSecondPassword)
 	tc.Password = esSecondPassword
@@ -371,7 +396,7 @@ func NewElasticSearchEnv(t *testing.T, client *http.Client, retAddress string) *
 func (e *ElasticSearchEnv) Authenticate(t *testing.T, user, password string) bool {
 	t.Helper()
 
-	endpoint := "/_xpack/security/_authenticate"
+	endpoint := path.Join(e.XPackStr, "_authenticate")
 	method := http.MethodGet
 
 	req, err := http.NewRequest(method, e.BaseURL+endpoint, nil)
@@ -404,7 +429,7 @@ func (e *ElasticSearchEnv) Authenticate(t *testing.T, user, password string) boo
 func (e *ElasticSearchEnv) SetPassword(t *testing.T, user, password string) {
 	t.Helper()
 
-	endpoint := "/_xpack/security/user/" + user + "/_password"
+	endpoint := path.Join(e.XPackStr, "/user/", user, "/_password")
 	method := http.MethodPut
 
 	body, err := json.Marshal(map[string]string{"password": password})
@@ -423,10 +448,10 @@ func (e *ElasticSearchEnv) SetPassword(t *testing.T, user, password string) {
 func (e *ElasticSearchEnv) createVaultRole(t *testing.T) {
 	t.Helper()
 
-	endpoint := "/_xpack/security/role/vault"
+	endpoint := path.Join(e.XPackStr, "/role/vault")
 	method := http.MethodPost
 
-	body, err := json.Marshal(map[string][]string{"cluster": []string{"manage_security"}})
+	body, err := json.Marshal(map[string][]string{"cluster": []string{"manage_security", "monitor"}})
 	if err != nil {
 		t.Fatalf("failed to marshal the body to create the vault role: %s", err)
 	}
@@ -443,7 +468,7 @@ func (e *ElasticSearchEnv) CreateVaultUser(t *testing.T) {
 	t.Helper()
 	e.createVaultRole(t)
 
-	endpoint := "/_xpack/security/user/" + esVaultUser
+	endpoint := path.Join(e.XPackStr, "/user/", esVaultUser)
 	method := http.MethodPost
 
 	type user struct {

--- a/mock/elasticsearch_responses.go
+++ b/mock/elasticsearch_responses.go
@@ -27,4 +27,10 @@ const (
 	deleteUserResponseTpl = `{
 	  "found" : %s
 	}`
+
+	infoResponseTpl = `{
+		"version" : {
+		  "number" : "%s"
+		}
+	}`
 )


### PR DESCRIPTION
# Overview
Changes the x-pack URL used based on the elasticsearch version in use. Fetches the elasticsearch version from the base url endpoint, and stores in the client for subsequent calls.

# Design of Change
Added a new setSecurityPath() function to the client, which checks if the security API path is already set. If it's not set, then it fetches the elasticsearch version from the base URL endpoint. If the version is >= 7, the API path is set to `/_security`, otherwise it's set to `/_xpack/security`. The setSecurityPath() function is called at the top of the other client functions.

# Related Issues/Pull Requests
https://github.com/hashicorp/vault-plugin-database-elasticsearch/issues/17

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
