### PR TITLE
test/acceptance: allow any 2xx success response

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -484,8 +484,15 @@ func (e *Environment) Test_Raciness(t *testing.T) {
 
 func testResponseSuccess(t *testing.T, resp *http.Response) {
 	t.Helper()
+	if resp == nil {
+		t.Fatalf("expected Success but received nil")
+	}
+
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		var body []byte
+		if resp.Body != nil {
+			body, _ = ioutil.ReadAll(resp.Body)
+		}
 		t.Fatalf("expected Success but received %d: %s", resp.StatusCode, string(body))
 	}
 }


### PR DESCRIPTION
# Overview

Update the acceptance tests to allow any 2xx success response. This is in response to a change in a vault endpoint see: https://github.com/hashicorp/vault/pull/14256



### Acceptance test output

```
=== RUN   Test_Acceptance
2022/02/24 15:34:20 running tests against the Elasticsearch url provided
2022/02/24 15:34:20 enabling database secrets engine
=== RUN   Test_Acceptance/write_a_config
=== RUN   Test_Acceptance/test_internally_defined_roles
2022/02/24 15:34:20 [DEBUG] DELETE http://localhost:9200/_xpack/security/user/v-token-internally-defi-OV4jqKpWHgfg8BRuQfqf-1645738460
2022/02/24 15:34:20 [DEBUG] DELETE http://localhost:9200/_xpack/security/role/v-token-internally-defi-OV4jqKpWHgfg8BRuQfqf-1645738460
=== RUN   Test_Acceptance/test_externally_defined_roles
2022/02/24 15:34:20 [DEBUG] DELETE http://localhost:9200/_xpack/security/user/v-token-externally-defi-rewyGmKaHrhlNhqbrkf7-1645738460
=== RUN   Test_Acceptance/test_credential_renewal
=== RUN   Test_Acceptance/test_credential_revocation
=== RUN   Test_Acceptance/test_root_credential_rotation
=== RUN   Test_Acceptance/check_raciness
--- PASS: Test_Acceptance (10.57s)
    --- PASS: Test_Acceptance/write_a_config (0.09s)
    --- PASS: Test_Acceptance/test_internally_defined_roles (0.25s)
    --- PASS: Test_Acceptance/test_externally_defined_roles (0.18s)
    --- PASS: Test_Acceptance/test_credential_renewal (0.01s)
    --- PASS: Test_Acceptance/test_credential_revocation (0.03s)
    --- SKIP: Test_Acceptance/test_root_credential_rotation (0.00s)
    --- PASS: Test_Acceptance/check_raciness (10.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-database-elasticsearch	10.753s
?   	github.com/hashicorp/vault-plugin-database-elasticsearch/cmd/vault-plugin-database-elasticsearch	[no test files]
?   	github.com/hashicorp/vault-plugin-database-elasticsearch/mock	[no test files]
```