### PR TITLE
Update the X-Pack URL for ES 6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"cluster": ["manage_security"]}' \
-    http://elastic:$PASSWORD@localhost:9200/_xpack/security/role/vault
+    http://elastic:$PASSWORD@localhost:9200/_security/role/vault
 ```
 
 Next, create a user for Vault associated with that role.
@@ -62,7 +62,7 @@ $ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d @data.json \
-    http://elastic:$PASSWORD@localhost:9200/_xpack/security/user/vault
+    http://elastic:$PASSWORD@localhost:9200/_security/user/vault
 ```
 
 The contents of `data.json` in this example are:

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -58,7 +59,7 @@ $ curl \
     -k -X POST \
     -H "Content-Type: application/json" \
     -d '{"cluster": ["manage_security"]}' \
-    https://elastic:$ES_PASSWORD@localhost:9200/_xpack/security/role/vault
+    https://elastic:$ES_PASSWORD@localhost:9200/_security/role/vault
 
 */
 func Test_Acceptance(t *testing.T) {
@@ -91,6 +92,13 @@ func Test_Acceptance(t *testing.T) {
 		}
 		if os.Getenv("CLIENT_KEY") != "" {
 			env.Config["client_key"] = os.Getenv("CLIENT_KEY")
+		}
+		if os.Getenv("USE_OLD_XPACK") != "" {
+			b, err := strconv.ParseBool(os.Getenv("USE_OLD_XPACK"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			env.Config["use_old_xpack"] = b
 		}
 	} else {
 		log.Print("running tests against mocked Elasticsearch")
@@ -165,6 +173,9 @@ func (e *Environment) Test_WriteConfig(t *testing.T) {
 	}
 	if connectionDetails["password"] != nil {
 		t.Fatal("password should not be returned!!!!")
+	}
+	if e.Config["use_old_xpack"] != connectionDetails["use_old_xpack"] {
+		t.Fatalf(`expected "use_old_xpack" %v but received %s`, e.Config["use_old_xpack"], connectionDetails["use_old_xpack"])
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -107,21 +107,25 @@ func TestClient_BadResponses(t *testing.T) {
 func giveBadResponses(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/_xpack/security/role/200-but-body-changed":
+	case "/_security/role/200-but-body-changed":
 		w.WriteHeader(200)
 		w.Write([]byte(`<html>I switched to html!</html>`))
 		return
 
 	case "/_xpack/security/role/404-not-found":
+	case "/_security/role/404-not-found":
 		w.WriteHeader(404)
 		w.Write([]byte(`{"something": "unexpected"}`))
 		return
 
 	case "/_xpack/security/role/500-mysterious-internal-server-error":
+	case "/_security/role/500-mysterious-internal-server-error":
 		w.WriteHeader(500)
 		w.Write([]byte(`<html>Internal Server Error</html>`))
 		return
 
 	case "/_xpack/security/role/503-unavailable":
+	case "/_security/role/503-unavailable":
 		w.WriteHeader(503)
 		w.Write([]byte(`<html>Service Unavailable</html>`))
 		return

--- a/mock/fake_elasticsearch.go
+++ b/mock/fake_elasticsearch.go
@@ -66,9 +66,16 @@ func (f *FakeElasticsearch) HandleRequests(w http.ResponseWriter, r *http.Reques
 			return
 		}
 	}
-	objName := strings.Split(r.URL.Path, "/")[4]
+	pathSplit := strings.Split(r.URL.Path, "/")
+	objName := ""
+	if strings.HasPrefix(r.URL.Path, "/_security") {
+		objName = pathSplit[3]
+	} else {
+		objName = pathSplit[4]
+	}
 	switch {
 	case strings.HasPrefix(r.URL.Path, "/_xpack/security/role/"):
+	case strings.HasPrefix(r.URL.Path, "/_security/role/"):
 		switch r.Method {
 		case http.MethodPost:
 			if _, found := f.Roles[objName]; found {
@@ -97,6 +104,7 @@ func (f *FakeElasticsearch) HandleRequests(w http.ResponseWriter, r *http.Reques
 			return
 		}
 	case strings.HasPrefix(r.URL.Path, "/_xpack/security/user/") && !strings.HasSuffix(r.URL.Path, "_password"):
+	case strings.HasPrefix(r.URL.Path, "/_security/user/") && !strings.HasSuffix(r.URL.Path, "_password"):
 		switch r.Method {
 		case http.MethodPost:
 			if _, found := f.Users[objName]; found {
@@ -116,6 +124,7 @@ func (f *FakeElasticsearch) HandleRequests(w http.ResponseWriter, r *http.Reques
 			return
 		}
 	case strings.HasPrefix(r.URL.Path, "/_xpack/security/user/") && strings.HasSuffix(r.URL.Path, "_password"):
+	case strings.HasPrefix(r.URL.Path, "/_security/user/") && strings.HasSuffix(r.URL.Path, "_password"):
 		switch r.Method {
 		case http.MethodPost:
 			if body["password"].(string) == "" {

--- a/scripts/run_acceptance.sh
+++ b/scripts/run_acceptance.sh
@@ -29,5 +29,6 @@ export VAULT_TOKEN=root
 # export CA_CERT=$PWD/scripts/certs/ca/ca.crt
 # export CLIENT_CERT=$PWD/scripts/certs/es01/es01.crt
 # export CLIENT_KEY=$PWD/scripts/certs/es01/es01.key
+# export USE_OLD_XPACK=true
 
 go test -v ./... -run Test_Acceptance


### PR DESCRIPTION
# Overview
Use the new `/_security` base URL instead of `/_xpack/security` when managing elasticsearch. Users can swich back to the old URL by setting the bool config option `use_old_xpack=true`.

# Design of Change
Adds an optional bool config option `use_old_xpack` to allow switching back to the old URL. Also modifies the container integration tests to run against elasticsearch versions 6, 7, and 8.

# Related Issues/Pull Requests
#17

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [X] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)

<details>
<summary>Acceptance tests against Elasticsearch 6.8.0</summary>

```console
$ USE_OLD_XPACK=true ./scripts/run_acceptance.sh
[...]
=== RUN   Test_Acceptance
2022/05/24 23:16:18 running tests against the Elasticsearch url provided
2022/05/24 23:16:18 enabling database secrets engine
=== RUN   Test_Acceptance/write_a_config
=== RUN   Test_Acceptance/test_internally_defined_roles
2022/05/24 23:16:18 [DEBUG] DELETE http://localhost:9200/_xpack/security/user/v-token-internally-defi-seskHPGyj41uRvg8uceh-1653459378
2022/05/24 23:16:18 [DEBUG] DELETE http://localhost:9200/_xpack/security/role/v-token-internally-defi-seskHPGyj41uRvg8uceh-1653459378
=== RUN   Test_Acceptance/test_externally_defined_roles
2022/05/24 23:16:18 [DEBUG] DELETE http://localhost:9200/_xpack/security/user/v-token-externally-defi-U3fMmoZc0eGSEz2s6QXQ-1653459378
=== RUN   Test_Acceptance/test_credential_renewal
=== RUN   Test_Acceptance/test_credential_revocation
=== RUN   Test_Acceptance/test_root_credential_rotation
=== RUN   Test_Acceptance/check_raciness
--- PASS: Test_Acceptance (10.65s)
    --- PASS: Test_Acceptance/write_a_config (0.19s)
    --- PASS: Test_Acceptance/test_internally_defined_roles (0.25s)
    --- PASS: Test_Acceptance/test_externally_defined_roles (0.17s)
    --- PASS: Test_Acceptance/test_credential_renewal (0.01s)
    --- PASS: Test_Acceptance/test_credential_revocation (0.03s)
    --- SKIP: Test_Acceptance/test_root_credential_rotation (0.00s)
    --- PASS: Test_Acceptance/check_raciness (10.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-database-elasticsearch	10.930s
?   	github.com/hashicorp/vault-plugin-database-elasticsearch/cmd/vault-plugin-database-elasticsearch	[no test files]
?   	github.com/hashicorp/vault-plugin-database-elasticsearch/mock	[no test files]
```
</details>

<details>
<summary>Acceptance tests against Elasticsearch 8.1.3</summary>

```console
$ ./scripts/run_acceptance.sh
[...]
=== RUN   Test_Acceptance
2022/05/24 23:19:46 running tests against the Elasticsearch url provided
2022/05/24 23:19:46 enabling database secrets engine
=== RUN   Test_Acceptance/write_a_config
=== RUN   Test_Acceptance/test_internally_defined_roles
2022/05/24 23:19:46 [DEBUG] DELETE http://localhost:9200/_security/user/v-token-internally-defi-TRYOdEbdKOkIiZtPgDXZ-1653459586
2022/05/24 23:19:46 [DEBUG] DELETE http://localhost:9200/_security/role/v-token-internally-defi-TRYOdEbdKOkIiZtPgDXZ-1653459586
=== RUN   Test_Acceptance/test_externally_defined_roles
2022/05/24 23:19:46 [DEBUG] DELETE http://localhost:9200/_security/user/v-token-externally-defi-h4lPZ6uYkYfoHaU5GeEQ-1653459586
=== RUN   Test_Acceptance/test_credential_renewal
=== RUN   Test_Acceptance/test_credential_revocation
=== RUN   Test_Acceptance/test_root_credential_rotation
=== RUN   Test_Acceptance/check_raciness
--- PASS: Test_Acceptance (10.77s)
    --- PASS: Test_Acceptance/write_a_config (0.19s)
    --- PASS: Test_Acceptance/test_internally_defined_roles (0.25s)
    --- PASS: Test_Acceptance/test_externally_defined_roles (0.21s)
    --- PASS: Test_Acceptance/test_credential_renewal (0.00s)
    --- PASS: Test_Acceptance/test_credential_revocation (0.11s)
    --- SKIP: Test_Acceptance/test_root_credential_rotation (0.00s)
    --- PASS: Test_Acceptance/check_raciness (10.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-database-elasticsearch	10.959s
?   	github.com/hashicorp/vault-plugin-database-elasticsearch/cmd/vault-plugin-database-elasticsearch	[no test files]
?   	github.com/hashicorp/vault-plugin-database-elasticsearch/mock	[no test files]
```

</details>

- [X] Backwards compatible
