### PR TITLE
Update error message for invalid api response

### DIFF
--- a/client.go
+++ b/client.go
@@ -250,5 +250,5 @@ func (c *Client) do(ctx context.Context, req *http.Request, ret interface{}) err
 	}
 
 	// We received some sort of API error. Let's return it.
-	return fmt.Errorf("error returned from elasticsearchapi: %d", resp.StatusCode)
+	return fmt.Errorf("error returned from elasticsearch api: %d", resp.StatusCode)
 }

--- a/client.go
+++ b/client.go
@@ -237,7 +237,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, ret interface{}) err
 		}
 		if err := json.Unmarshal(body, ret); err != nil {
 			// We received a success response from the ES API but the body was in an unexpected format.
-			return fmt.Errorf("%s; %d: %s", err, resp.StatusCode, body)
+			return fmt.Errorf("unexpected format from elasticsearch api:%s; %d", err, resp.StatusCode)
 		}
 		// Body has been successfully read out.
 		return nil

--- a/client.go
+++ b/client.go
@@ -237,7 +237,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, ret interface{}) err
 		}
 		if err := json.Unmarshal(body, ret); err != nil {
 			// We received a success response from the ES API but the body was in an unexpected format.
-			return fmt.Errorf("unexpected format from elasticsearch api:%s; %d", err, resp.StatusCode)
+			return fmt.Errorf("unexpected format from elasticsearch api: %s; %d", err, resp.StatusCode)
 		}
 		// Body has been successfully read out.
 		return nil

--- a/client.go
+++ b/client.go
@@ -250,5 +250,5 @@ func (c *Client) do(ctx context.Context, req *http.Request, ret interface{}) err
 	}
 
 	// We received some sort of API error. Let's return it.
-	return fmt.Errorf("%d: %s", resp.StatusCode, body)
+	return fmt.Errorf("error returned from elasticsearchapi: %d", resp.StatusCode)
 }


### PR DESCRIPTION
# Overview

Provides a more descriptive error message in the event of a malformed API response from the elasticsearch api

# Related Issues/Pull Requests


# Contributor Checklist


[x] Backwards compatible
