### PR TITLE
[CHANGELOG] Prepare for v0.20.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.20.1
+### March 20, 2026
+
+* Update dependecies (#124)
+
 ## Unreleased
 ## v0.20.1
 ### March 20, 2026


### PR DESCRIPTION
Changelog update for version [v0.20.1](https://github.com/hashicorp/vault-plugin-database-elasticsearch/releases/tag/v0.20.1).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/23324557954

